### PR TITLE
Remove composer.json version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "A Bundle for OroCommerce to provide application level geo-detection using the maxmind db",
     "type": "library",
     "license": "GPL-3.0",
-    "version": "4.2.0",
     "authors": [
         {
             "name": "Adam Hall",


### PR DESCRIPTION
This PR just removes the version number from the composer.json so that it relies entirely on the github tag in packagist.