### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OroCommerce Geo Detection Bundle
 
 Facts
 -----
-- version: 5.0.0
+- version: 6.0.0
 - composer name: aligent/oro-geo-detection
 
 Description

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "5.0.*",
+    "oro/commerce": "6.0.*",
     "geoip2/geoip2": "~2.0",
     "guzzlehttp/guzzle": "^7.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^1.7",
-    "phpmd/phpmd": "^2.12",
-    "friendsofphp/php-cs-fixer": "~2.18.2 || ~3.1.0 || ~3.4.0",
-    "nelmio/alice": "~3.8.0 || ~3.9.0",
-    "theofidry/alice-data-fixtures": "~1.4.0 || ~1.5.0",
-    "symfony/phpunit-bridge": "~4.4.24 || ~6.1.0",
-    "squizlabs/php_codesniffer": "^3.6"
+    "phpstan/phpstan": "~1.10.0",
+    "phpmd/phpmd": "^2.15",
+    "friendsofphp/php-cs-fixer": "~2.18.2 || ~3.1.0 || ~3.57.0",
+    "nelmio/alice": "~3.8.0 || ~3.12.1",
+    "theofidry/alice-data-fixtures": "~1.4.0 || ~1.6.0",
+    "symfony/phpunit-bridge": "~4.4.24 || ~6.4.0",
+    "squizlabs/php_codesniffer": "^3.10.1"
   }
 }

--- a/src/AligentGeoDetectionBundle.php
+++ b/src/AligentGeoDetectionBundle.php
@@ -16,5 +16,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AligentGeoDetectionBundle extends Bundle
 {
-
 }

--- a/src/Cache/GeoIpCacheWarmer.php
+++ b/src/Cache/GeoIpCacheWarmer.php
@@ -17,7 +17,6 @@ use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
 use PharData;
-use PharFileInfo;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -70,7 +69,7 @@ class GeoIpCacheWarmer implements CacheWarmerInterface
      *
      * @return bool true if the warmer is optional, false otherwise
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }
@@ -80,12 +79,12 @@ class GeoIpCacheWarmer implements CacheWarmerInterface
      *
      * {@inheritdoc}
      */
-    public function warmUp($cacheDir): void
+    public function warmUp($cacheDir): array
     {
         //avoid downloading if db is up to date
         if ($this->isGeoDatabaseUpToDate()) {
             $this->logger->info('Geo Database still up to date, no new download triggered');
-            return;
+            return [];
         }
 
         $tempWorkingDir = dirname($cacheDir) . static::GEO_TEMP_DIR;
@@ -99,6 +98,8 @@ class GeoIpCacheWarmer implements CacheWarmerInterface
         $tempDownloadFilePath = $this->downloadGeoDatabase($databaseUrl, $tempWorkingDir);
         $this->decompressAndMove($tempDownloadFilePath, $this->database, $tempWorkingDir);
         $this->removeTempWorkingDir($tempWorkingDir);
+
+        return [];
     }
 
     protected function isGeoDatabaseUpToDate()

--- a/src/DependencyInjection/AligentGeoDetectionExtension.php
+++ b/src/DependencyInjection/AligentGeoDetectionExtension.php
@@ -12,10 +12,10 @@
 
 namespace Aligent\GeoDetectionBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class AligentGeoDetectionExtension extends Extension
 {
@@ -43,7 +43,7 @@ class AligentGeoDetectionExtension extends Extension
     /**
      * @return string
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return static::ALIAS;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,10 +31,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(AligentGeoDetectionExtension::ALIAS);
         $rootNode = $treeBuilder->getRootNode();
@@ -60,7 +58,7 @@ class Configuration implements ConfigurationInterface
      * @param string $name
      * @return string
      */
-    public static function getConfigKeyByName($name)
+    public static function getConfigKeyByName($name): string
     {
         return sprintf(
             AligentGeoDetectionExtension::ALIAS . '%s%s',

--- a/src/Form/Type/GeoDetectionCountriesCollectionType.php
+++ b/src/Form/Type/GeoDetectionCountriesCollectionType.php
@@ -36,7 +36,7 @@ class GeoDetectionCountriesCollectionType extends AbstractType
     /**
      * @return string
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CollectionType::class;
     }
@@ -52,7 +52,7 @@ class GeoDetectionCountriesCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Form/Type/GeoDetectionCountriesSystemConfigType.php
+++ b/src/Form/Type/GeoDetectionCountriesSystemConfigType.php
@@ -39,7 +39,7 @@ class GeoDetectionCountriesSystemConfigType extends AbstractType
     /**
      * @return string
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return GeoDetectionCountriesCollectionType::class;
     }
@@ -55,7 +55,7 @@ class GeoDetectionCountriesSystemConfigType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return static::NAME;
     }

--- a/src/Form/Type/GeoDetectionCountryType.php
+++ b/src/Form/Type/GeoDetectionCountryType.php
@@ -69,7 +69,7 @@ class GeoDetectionCountryType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return $this->getName();
     }

--- a/src/Layout/Extension/GeoDetectionContextConfigurator.php
+++ b/src/Layout/Extension/GeoDetectionContextConfigurator.php
@@ -53,7 +53,7 @@ class GeoDetectionContextConfigurator implements ContextConfiguratorInterface
         RedirectionConfigurationProvider $configurationProvider,
         RequestStack $requestStack
     ) {
-    
+
         $this->reader = $reader;
         $this->frontendHelper = $frontendHelper;
         $this->redirectionConfigProvider = $configurationProvider;

--- a/src/Providers/GeoDetectionProvider.php
+++ b/src/Providers/GeoDetectionProvider.php
@@ -3,11 +3,10 @@
 namespace Aligent\GeoDetectionBundle\Providers;
 
 use Doctrine\Common\Cache\CacheProvider;
-use GeoIp2\Exception\AddressNotFoundException;
+use GeoIp2\Database\Reader;
 use Oro\Bundle\FrontendBundle\Request\FrontendHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use GeoIp2\Database\Reader;
 
 /**
  * Class GeoDetectionProvider

--- a/src/Providers/RedirectionConfigurationProvider.php
+++ b/src/Providers/RedirectionConfigurationProvider.php
@@ -54,7 +54,6 @@ class RedirectionConfigurationProvider
                 return $site;
             }
         }
-        return;
     }
 
     /**
@@ -74,7 +73,7 @@ class RedirectionConfigurationProvider
     /**
      * @return array
      */
-    public function getEnabledWebsites()
+    public function getEnabledWebsites(): array
     {
         return $this->enabledRedirects;
     }
@@ -90,7 +89,7 @@ class RedirectionConfigurationProvider
     /**
      * @return bool
      */
-    public function hasRedirects()
+    public function hasRedirects(): bool
     {
         return count($this->enabledRedirects) > 0;
     }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -70,9 +70,10 @@ services:
 
     # Cache Provider
     aligent_geo_detection.cache:
-        parent: oro.cache.abstract
-        calls:
-            - [ setNamespace, [ 'geo_ip' ] ]
+        #        public: false
+        parent: oro.data.cache
+        tags:
+            - { name: 'cache.pool', namespace: 'geo_ip' }
 
     # Blocks
     aligent_geo_detection.layout.block_type.redirection_block:

--- a/src/Tests/Unit/DependencyInjection/AligentGeoDetectionExtensionTest.php
+++ b/src/Tests/Unit/DependencyInjection/AligentGeoDetectionExtensionTest.php
@@ -7,6 +7,7 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
+
 namespace Aligent\GeoDetectionBundle\Tests\Unit\DependencyInjection;
 
 use Aligent\GeoDetectionBundle\DependencyInjection\AligentGeoDetectionExtension;

--- a/src/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -7,6 +7,7 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
+
 namespace Aligent\GeoDetectionBundle\Tests\Unit\DependencyInjection;
 
 use Aligent\GeoDetectionBundle\DependencyInjection\Configuration;


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- Added some return types/type hints
- Deleted not needed annotations
- Added some CS fixes
- Updated aligent_geo_detection.cache service definition according to the oro/platform changelog
